### PR TITLE
Prop Remover Module and Config Option

### DIFF
--- a/gamemode/config.lua
+++ b/gamemode/config.lua
@@ -278,6 +278,7 @@ BaseWars.Config = {
 
 	CustomChat			= true,
 	ExtraStuff			= true,
+	CleanProps			= false, -- Finds all physics props on the map and removes them when all the entities are frist initialized (AKA: When the map first loads).
 
 	AllowFriendlyFire	= false,
 

--- a/gamemode/modules/prop_remover.lua
+++ b/gamemode/modules/prop_remover.lua
@@ -11,7 +11,6 @@ local function RemoveProps()
 end
 
 hook.Add( "InitPostEntity", "RemoveProps", function()
-	//print( "MPR: Initialization Hook Called" )
 	if BaseWars.Config.CleanProps then
 	RemoveProps()
 	end

--- a/gamemode/modules/prop_remover.lua
+++ b/gamemode/modules/prop_remover.lua
@@ -1,0 +1,18 @@
+MODULE.Name 	= "Prop Remover"
+MODULE.Author 	= "BROLY" --Thanks to Q2F2 for the tip on what function to hook!
+// Finds all physics props on the map and removes them when all the entities are frist initialized (AKA: When the map first loads).
+
+local function RemoveProps()
+		for k, v in pairs( ents.FindByClass( "prop_physics*" ) ) do
+			print( "PR: Removing: ", v:GetPos() )
+			v:Remove()
+		end
+		print( "PR: All Props Removed!" )
+end
+
+hook.Add( "InitPostEntity", "RemoveProps", function()
+	//print( "MPR: Initialization Hook Called" )
+	if BaseWars.Config.CleanProps then
+	RemoveProps()
+	end
+end )

--- a/gamemode/modules/prop_remover.lua
+++ b/gamemode/modules/prop_remover.lua
@@ -3,12 +3,18 @@ MODULE.Author 	= "BROLY" --Thanks to Q2F2 for the tip on what function to hook!
 // Finds all physics props on the map and removes them when all the entities are frist initialized (AKA: When the map first loads).
 
 local function RemoveProps()
-		for k, v in pairs( ents.FindByClass( "prop_physics*" ) ) do
-			print( "PR: Removing: ", v:GetPos() )
+	BaseWars.UTIL.Log( "Prop Remover: Removing Map Props")
+		for k, v in pairs( ents.FindByClass( "prop_physics*" ) ) do		
 			v:Remove()
 		end
-		print( "PR: All Props Removed!" )
+	BaseWars.UTIL.Log( "Prop Remover: All Map Props Removed!" )
 end
+
+hook.Add( "PostCleanupMap", "CleanEverythingCheck", function()
+	if BaseWars.Config.CleanProps then
+	RemoveProps()
+	end
+end )
 
 hook.Add( "InitPostEntity", "RemoveProps", function()
 	if BaseWars.Config.CleanProps then


### PR DESCRIPTION
Could be of use to other server owners as well.
Good for RP maps with a bunch of props on them that are not needed.

Defaulted to false.